### PR TITLE
Fix code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
     "zod": "^3.22.4",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
Fixes [https://github.com/RectiFlex/AI_CO_FOUNDER/security/code-scanning/8](https://github.com/RectiFlex/AI_CO_FOUNDER/security/code-scanning/8)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent abuse by limiting the number of requests a user can make within a specified time frame.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `api/index.ts` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the routes that perform sensitive operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Introduce rate limiting to prevent abuse by limiting the number of requests a user can make within a specified time frame.