### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -230,6 +230,7 @@ app.delete('/api/ideas/:id', authenticate, async (req, res) => {
 
 // Documents endpoints
 app.post('/api/documents', 
+  limiter,
   authenticate,
   body('type').notEmpty(),
   body('title').notEmpty(),


### PR DESCRIPTION
Fixes [https://github.com/RectiFlex/AI_CO_FOUNDER/security/code-scanning/5](https://github.com/RectiFlex/AI_CO_FOUNDER/security/code-scanning/5)

To fix the problem, we need to apply the existing rate limiter middleware to the `/api/documents` endpoint. This will ensure that the endpoint is protected against denial-of-service attacks by limiting the number of requests that can be made in a given time window.

- We will add the `limiter` middleware to the `/api/documents` endpoint.
- This change will be made in the `api/index.ts` file.
- No new methods or definitions are needed, as the `limiter` middleware is already defined and imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Apply rate limiting to the '/api/documents' endpoint to prevent denial-of-service attacks.