### PR TITLE
Fix code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -208,7 +208,7 @@ app.put('/api/ideas/:id',
     }
 });
 
-app.delete('/api/ideas/:id', authenticate, async (req, res) => {
+app.delete('/api/ideas/:id', limiter, authenticate, async (req, res) => {
   const { id } = req.params;
   const userId = req.user.userId;
 


### PR DESCRIPTION
Fixes [https://github.com/RectiFlex/AI_CO_FOUNDER/security/code-scanning/4](https://github.com/RectiFlex/AI_CO_FOUNDER/security/code-scanning/4)

To fix the problem, we need to apply the existing rate limiter middleware to the `/api/ideas/:id` DELETE endpoint. This will ensure that the endpoint is protected against excessive requests, thereby mitigating the risk of a denial-of-service attack.

- Add the `limiter` middleware to the DELETE endpoint on line 211.
- Ensure that the rate limiter is configured correctly to limit the number of requests per defined time window.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Apply rate limiting to the DELETE /api/ideas/:id endpoint to prevent excessive requests and mitigate denial-of-service risks.